### PR TITLE
updated your benchmark to build with ezjsonm 0.4.2

### DIFF
--- a/lib/bench_read.ml
+++ b/lib/bench_read.ml
@@ -5,7 +5,8 @@ let random_json =
   let random_events =
     1_000
     |> List.init ~f:(fun _ -> Random_data.random_event ())
-    |> List.map ~f:Random_data.Ez.to_json in
+    |> List.map ~f:Random_data.Ez.to_json  
+  in
   (`A random_events) |> Ezjsonm.to_string
 
 let () =
@@ -21,16 +22,20 @@ let () =
     (*   random_json |> Yojson.Safe.from_string |> ignore *)
     (* ); *)
     Bench.Test.create ~name:"ezjsonm read" (fun () ->
-      random_json
-      |> Ezjsonm.from_string
-      |> Ezjsonm.get_list Random_data.Ez.of_json
-      |> ignore
+      let event_list : Random_data.event list =
+	random_json
+        |> Ezjsonm.from_string
+        |> Ezjsonm.get_list Random_data.Ez.of_json
+      in
+      ignore event_list
     );
     Bench.Test.create ~name:"yojson read" (fun () ->
-      random_json
-      |> Yojson.Basic.from_string
-      |> Yojson.Basic.Util.to_list
-      |> List.map ~f:Random_data.Yo.of_json
-      |> ignore
+      let event_list : Random_data.event list =
+        random_json
+        |> Yojson.Basic.from_string
+        |> Yojson.Basic.Util.to_list
+        |> List.map ~f:Random_data.Yo.of_json
+      in
+      ignore event_list
     );
   ]

--- a/lib/random_data.ml
+++ b/lib/random_data.ml
@@ -45,7 +45,7 @@ module type Json_intf = sig
   val of_json : json -> event
 end
 
-module Ez : sig include Json_intf with type json := Ezjsonm.t end =
+module Ez : sig include Json_intf with type json := Ezjsonm.value end =
 struct
   open Ezjsonm
   let to_json { username; date; event_type; payload } =
@@ -99,4 +99,7 @@ let random_event () =
 
 let random_event_json () =
   let event = random_event () in
-  event |> Ez.to_json |> Ezjsonm.to_string
+  event 
+  |> Ez.to_json 
+  |> Ezjsonm.wrap
+  |> Ezjsonm.to_string


### PR DESCRIPTION
Hi,

I wanted to try out your benchmark but the version of ezjsonm I found in opam (v0.4.2) must have changed a little.  The attached patch updates the benchmark to build with this new version.

FWIW on my 2014-era Macbook Pro, Yojson is still 2-3x faster than Ezjsonm.

Andy
